### PR TITLE
Constrained-host adoption: opt-in embeddings, CLI in synapse-os, episodic cron reliability, honest docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning: [S
 ## [Unreleased]
 
 ### Added
+- CLI inside the published `synapse-os` package: `remember`, `query`, `list`, `get`,
+  `delete`, `import`, `export`, `reembed`, `backup`, `restore` — same store, env,
+  and write guards as the MCP server. No args (or `mcp`) still starts the stdio
+  MCP server, so existing `npx -y synapse-os` client configs keep working.
+- Hermes / constrained-environment guide (`integrations/hermes/`): correct
+  `env:`-object MCP YAML, `--ignore-scripts` install path, Ollama embeddings,
+  episodic cron-log patterns (no entityKey on run logs), WAL read-only inspect.
+- Startup embedding report on stderr: active provider + whether vectors are
+  semantic; loud warning in hash mode. `GET /health` now reports the same.
+- Daily TTL/decay re-sweep in long-lived MCP processes (was startup-only).
+
+### Changed
+- **Breaking (defaults):** embedding provider default is no longer `local`.
+  Selection: explicit `SYNAPSE_EMBED_PROVIDER` wins; a configured
+  `SYNAPSE_EMBED_API_KEY`/`SYNAPSE_EMBED_BASE_URL` implies `openai`; otherwise
+  `hash`. `npx -y synapse-os` no longer forces the transformers.js/ONNX stack —
+  `@huggingface/transformers` moved from a hard dependency to an optional peer
+  (install it explicitly for `SYNAPSE_EMBED_PROVIDER=local`).
+- Non-semantic embeddings (hash) no longer inject noise: the vector score term
+  is disabled, retrieval candidacy is FTS5-keyword-only, and write-time semantic
+  dedup/absorb is skipped. Golden-case evals are now measured in this worst-case
+  mode (precision@5 0.969, stale 0.000, pass 0.969).
+- Episodic memories are never semantically absorbed/deduped — distinct cron run
+  logs with near-identical wording all survive (exact-content dedup still applies).
+- README: honest provider matrix (size/network/toolchain per provider), local-first
+  and scale claims scoped to what is measured, stdio-vs-HTTP packaging clarified.
 - Graph-aware retrieval: 1-hop link expansion — a hit on a "chapter" memory pulls
   its "book" along via part_of/related_to links at half score, filling leftover
   limit slots; supersedes/contradicts edges are never followed. New `part_of`

--- a/README.md
+++ b/README.md
@@ -128,6 +128,50 @@ open http://localhost:8787/inspector
 ./scripts/demo.sh
 ```
 
+## The `synapse-os` package: CLI + MCP in one
+
+The published npm package is both the stdio MCP server **and** a full CLI sharing the same store, env vars, and write guards:
+
+```bash
+npx -y synapse-os                      # no args → stdio MCP server (existing configs keep working)
+npx -y synapse-os mcp                  # explicit MCP mode
+npx -y synapse-os remember semantic "User prefers TypeScript"
+npx -y synapse-os query "typescript preference"
+npx -y synapse-os list / get / delete / import / export
+npx -y synapse-os reembed              # after switching embedding provider/model
+npx -y synapse-os backup [dest] / restore <src> --force
+```
+
+**What's in the package:** the stdio MCP server + CLI, on better-sqlite3. The HTTP/SSE API and Inspector UI live in this monorepo (`apps/api`) and are **not** part of the `synapse-os` package — "works with any MCP client" means stdio. Heavy ML is opt-in: installing `synapse-os` does **not** pull transformers.js/ONNX; `SYNAPSE_EMBED_PROVIDER=local` requires a separate `npm i @huggingface/transformers`.
+
+To inspect the DB while an MCP host holds it (WAL mode allows concurrent readers): `npx -y synapse-os list`, or read-only SQL: `sqlite3 "file:$HOME/.synapse/synapse.db?mode=ro" "SELECT type, status, content FROM memories"`.
+
+### Constrained environments (containers, gateways, Hermes)
+
+Small `/tmp`, no native toolchain, or no GPU runtime? This is the supported path:
+
+```bash
+npm install -g synapse-os        # no onnxruntime, no model downloads
+# if install scripts are blocked or better-sqlite3 has no prebuilt binary for your platform:
+npm install -g synapse-os --ignore-scripts && (cd "$(npm root -g)/synapse-os" && npm rebuild better-sqlite3)
+```
+
+- Default embeddings are `hash` (non-semantic, loud warning at startup): retrieval runs on FTS5 + importance/recency — about 80% useful for structured/cron-log recall, blind to paraphrase.
+- For real semantic recall without heavy npm installs, use Ollama (see provider matrix) and run `synapse-os reembed` after switching.
+- Hermes MCP config — env vars go in an `env:` **object**, not `--env` CLI args:
+
+```yaml
+mcpServers:
+  synapse:
+    command: npx
+    args: ["-y", "synapse-os"]
+    env:
+      SYNAPSE_DB: /root/.synapse/synapse.db
+      SYNAPSE_EMBED_PROVIDER: hash
+```
+
+Full Hermes guide, including cron-run episodic logging patterns: [`integrations/hermes/`](integrations/hermes/).
+
 ## Use from any AI agent
 
 Synapse exposes `memory_write`, `memory_retrieve`, `memory_digest`, and `memory_feedback` over MCP. Any MCP-capable agent can use it — verified live with Claude Code (write in one session, recall in a fresh one).
@@ -205,9 +249,11 @@ Synapse refuses to store credentials. Every write path — MCP, HTTP API, CLI, t
 | Metric | Value |
 |--------|-------|
 | Golden cases | 32 |
-| Precision@5 | 0.984 |
+| Precision@5 | 0.969 |
 | Stale-fact rate | 0.000 |
 | Pass rate | 0.969 |
+
+Golden-case numbers are measured in **hash mode** (no semantic vectors — FTS5 + importance/recency/confidence only), i.e. the worst-case constrained-environment configuration. Real embedding providers add paraphrase recall on top. Scale caveat: these are personal-scale figures (hundreds to ~1K memories, linear vector scan); 10K+ retrieval is unbenchmarked — treat performance claims beyond that as unproven.
 
 On the external **engram-v3** benchmark (LongMemEval-format, 50 multi-session QA questions, LLM-judged): **96.0%** (48/50) — ingest the haystack sessions, retrieve, answer from retrieved memories only. Full results, metric caveats, and reproduction commands: [BENCHMARKS.md](BENCHMARKS.md).
 
@@ -225,26 +271,28 @@ Behavioral evals go beyond retrieval ranking and test outcomes — the failure m
 
 ### Where your data goes
 
-Storage and retrieval are fully local — SQLite on your disk, no network calls. Two paths send memory content off-device, and only when you opt into them:
+Storage and retrieval are local — SQLite on your disk. "Local-first" here means the store and ranking never need a network; some optional features do talk to endpoints you configure:
 
 - **Consolidation** (`POST /v1/jobs/consolidate`): new episodic memories are sent to the LLM at `SYNAPSE_LLM_BASE_URL` (default `https://api.openai.com/v1`) to extract semantic facts. Point it at a local model (e.g. Ollama) to keep everything on-device.
-- **Embeddings:** the default provider runs fully on-device (all-MiniLM-L6-v2 via transformers.js; the model itself downloads once from HuggingFace). Only the OpenAI-compatible embedder (`SYNAPSE_EMBED_PROVIDER=openai`) sends memory text to an external endpoint.
+- **Embeddings:** the default `hash` provider makes no network calls (and no semantic vectors — see the provider matrix below). `openai` sends memory text to whatever endpoint you configure (localhost for Ollama; a third party for hosted APIs). `local` (transformers.js) downloads the model once from HuggingFace, then runs fully on-device.
 
-If you never run consolidation and never configure a remote embedder, no memory content leaves your machine.
+With the defaults (hash, no consolidation), no memory content ever leaves your machine and no network request is made. With `local` embeddings, the only network traffic is the one-time model download.
 
-## Choosing your embedding model (plug and play)
+## Choosing your embedding provider (plug and play)
 
-Everything is switchable by env var — no code changes:
+Everything is switchable by env var — no code changes. Honest expectations per provider:
 
-| Setup | Env |
-|---|---|
-| Local, no API key (default) | `SYNAPSE_EMBED_PROVIDER=local` — all-MiniLM-L6-v2, 384 dims |
-| Local, different HF model | `SYNAPSE_EMBED_PROVIDER=local SYNAPSE_EMBED_MODEL=Xenova/bge-small-en-v1.5` |
-| Ollama (fully on-device) | `SYNAPSE_EMBED_PROVIDER=openai SYNAPSE_EMBED_BASE_URL=http://localhost:11434/v1 SYNAPSE_EMBED_MODEL=nomic-embed-text` |
-| OpenAI | `SYNAPSE_EMBED_PROVIDER=openai SYNAPSE_EMBED_API_KEY=sk-...` |
-| Offline deterministic (tests) | `SYNAPSE_EMBED_PROVIDER=hash` |
+| Provider | Env | Semantic? | Install weight | Network |
+|---|---|---|---|---|
+| `hash` (default) | `SYNAPSE_EMBED_PROVIDER=hash` | **No** — deterministic char-frequency vectors | zero extra | none |
+| `openai` — any OpenAI-compatible endpoint, incl. **Ollama** | `SYNAPSE_EMBED_PROVIDER=openai SYNAPSE_EMBED_BASE_URL=... SYNAPSE_EMBED_MODEL=...` (`SYNAPSE_EMBED_API_KEY` if the endpoint needs one) | Yes | zero extra | per-request to the endpoint (localhost for Ollama) |
+| `local` — transformers.js | `SYNAPSE_EMBED_PROVIDER=local` (+ optional `SYNAPSE_EMBED_MODEL=Xenova/bge-small-en-v1.5`) | Yes | **heavy, opt-in**: `npm i @huggingface/transformers` pulls the ONNX runtime (~100MB+ native binaries); model (~25MB) downloads once from HuggingFace | one-time model download, then fully on-device |
 
-**After switching provider or model, run `synapse reembed`** — it re-embeds every stored memory with the new model. Without it, old memories keep vectors the new model can't compare against and silently fall back to keyword-only scoring.
+**Default selection:** an explicit `SYNAPSE_EMBED_PROVIDER` always wins. Otherwise, if `SYNAPSE_EMBED_API_KEY` or `SYNAPSE_EMBED_BASE_URL` is set, Synapse assumes `openai`. Otherwise it runs `hash` and prints a loud startup warning: in hash mode the vector term is disabled entirely (no noise in the ranking) and retrieval works on FTS5 keyword search + importance/recency/confidence — genuinely useful for structured/keyword-ish recall, blind to paraphrase. Semantic dedup/absorb at write time is also disabled in hash mode, so near-duplicate wording is stored rather than mis-merged.
+
+**Recommended path for constrained environments** (containers, no native toolchain, small disks): Ollama — real embeddings, no npm-install weight: `ollama pull nomic-embed-text`, then the `openai` row above with `SYNAPSE_EMBED_BASE_URL=http://localhost:11434/v1`.
+
+**After switching provider or model, run `npx -y synapse-os reembed`** — it re-embeds every stored memory with the new model. Without it, old memories keep vectors the new model can't compare against and silently fall back to keyword-only scoring.
 
 The LLM for consolidation/conflict jobs is equally pluggable: `SYNAPSE_LLM_BASE_URL` + `SYNAPSE_LLM_MODEL` + `SYNAPSE_LLM_API_KEY` accept any OpenAI-compatible endpoint (Ollama, LM Studio, OpenRouter, ...). Library users can go further and inject any `EmbeddingProvider` implementation directly into `RetrievalService`/`writeMemory`.
 

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -68,7 +68,12 @@ export async function createServer(repo?: MemoryRepository, opts?: { port?: numb
     });
   }
 
-  app.get("/health", (c) => c.json({ ok: true, service: "synapse-api" }));
+  app.get("/health", (c) =>
+    c.json({
+      ok: true,
+      service: "synapse-api",
+      embeddings: { model: embedder.model, semantic: embedder.semantic !== false },
+    }));
 
   app.post("/v1/memories", async (c) => {
     const json: unknown = await c.req.json();
@@ -366,9 +371,9 @@ export async function createServer(repo?: MemoryRepository, opts?: { port?: numb
 
 // Default startup behavior
 if (process.argv[1] && process.argv[1].endsWith("server.ts")) {
-  // Real semantic embeddings by default when run as a server; tests that
-  // import createServer() directly keep the fast hash provider.
-  process.env.SYNAPSE_EMBED_PROVIDER ??= "local";
+  // Provider selection is shared with the CLI/MCP (see loadEmbeddingConfig):
+  // explicit SYNAPSE_EMBED_PROVIDER wins, a configured key/base URL implies
+  // openai, otherwise hash with a startup warning.
   createServer().then((server) => {
     const port = Number(process.env.PORT ?? 8787);
     console.log(`synapse-api listening on http://localhost:${port}`);

--- a/apps/mcp-server/README.md
+++ b/apps/mcp-server/README.md
@@ -1,10 +1,10 @@
 # synapse-os
 
-**Synapse — local-first long-term memory for AI agents, over MCP.**
+**Synapse — long-term memory for AI agents: stdio MCP server + CLI, on local SQLite.**
 
 > Chat history is a log. Synapse is a brain.
 
-Gives any MCP-capable agent (Claude Code, Claude Desktop, Cursor, OpenCode…) durable, typed memory on local SQLite: entity-key supersession ("I moved jobs" replaces the old employer instead of coexisting with it), conflict detection, decay with spaced reinforcement, feedback-driven confidence, and a credential write-gate. Retrieval is hybrid (vector + BM25 + importance + recency − decay) and 100% LLM-free.
+Gives any MCP-capable agent (Claude Code, Claude Desktop, Cursor, OpenCode, Hermes…) durable, typed memory: entity-key supersession ("I moved jobs" replaces the old employer instead of coexisting with it), conflict detection, decay with spaced reinforcement, feedback-driven confidence, and a credential write-gate. Retrieval is hybrid (vector + FTS5/BM25 + importance + recency − decay) and LLM-free.
 
 ## Install
 
@@ -12,17 +12,49 @@ Gives any MCP-capable agent (Claude Code, Claude Desktop, Cursor, OpenCode…) d
 claude mcp add --scope user synapse -- npx -y synapse-os
 ```
 
-Or any MCP client: stdio server, command `npx`, args `["-y", "synapse-os"]`.
+Or any MCP client: stdio server, command `npx`, args `["-y", "synapse-os"]`. Env vars go in the client's `env` object (for Hermes: an `env:` YAML mapping, not `--env` args).
+
+Constrained containers (small /tmp, blocked install scripts):
+
+```bash
+npm install -g synapse-os --ignore-scripts
+cd "$(npm root -g)/synapse-os" && npm rebuild better-sqlite3
+```
+
+## CLI
+
+The same binary is a full CLI over the same database (no args = MCP server, so existing configs keep working):
+
+```bash
+synapse-os remember semantic "User prefers TypeScript"
+synapse-os query "typescript preference"
+synapse-os list | get <id> | delete <id> | import <file.md> | export
+synapse-os reembed                      # after switching embedding provider/model
+synapse-os backup [dest] | restore <src> --force
+synapse-os mcp                          # explicit MCP mode
+```
+
+## Embeddings — honest defaults
+
+`npx -y synapse-os` does **not** download ML runtimes. Default provider selection:
+
+1. `SYNAPSE_EMBED_PROVIDER` set → that provider (`hash` | `openai` | `local`).
+2. Else `SYNAPSE_EMBED_API_KEY` or `SYNAPSE_EMBED_BASE_URL` set → `openai` (any OpenAI-compatible endpoint, including Ollama).
+3. Else → `hash`, with a loud startup warning: **not semantic.** The vector term is disabled; retrieval works on FTS5 keyword search + importance/recency/confidence. Good for structured/keyword recall, blind to paraphrase.
+
+Real semantic recall, lightest path (Ollama): `SYNAPSE_EMBED_PROVIDER=openai SYNAPSE_EMBED_BASE_URL=http://localhost:11434/v1 SYNAPSE_EMBED_MODEL=nomic-embed-text`. Heaviest path: `SYNAPSE_EMBED_PROVIDER=local` needs an explicit `npm i @huggingface/transformers` (pulls the ONNX runtime, ~100MB+; model downloads once from HuggingFace). **After switching providers run `synapse-os reembed`.**
 
 ## Tools
 
 | Tool | What it does |
 |---|---|
-| `memory_write` | Store a typed memory; `entityKey` makes it a current-value slot with automatic supersession. Credentials are rejected. |
+| `memory_write` | Store a typed memory; `entityKey` makes it a current-value slot with automatic supersession. Don't use `entityKey` for run/event logs — each write would supersede the previous run; use `type: "episodic"` + tags instead. Credentials are rejected. |
 | `memory_retrieve` | Hybrid-scored recall with trust qualifiers ("stored 8 months ago — may be outdated"). |
 | `memory_digest` | Always-on core memory block for session start. |
 | `memory_feedback` | `helpful` / `stale` / `wrong` — moves confidence, disputes, and durability. |
 
-Data lives in `~/.synapse/synapse.db`. Full docs, benchmarks (96.0% engram-v3, methodology and caveats included), and source: [github.com/Danialsamadi/synapse](https://github.com/Danialsamadi/synapse).
+Data lives in `~/.synapse/synapse.db` (override: `SYNAPSE_DB`). WAL mode allows concurrent readers while the server runs: `sqlite3 "file:$HOME/.synapse/synapse.db?mode=ro" "..."` or just `synapse-os list`.
+
+**Scope notes:** this package is the stdio MCP server + CLI. The HTTP API and Inspector UI live in the monorepo, not in this package. Benchmarked at personal scale (~1K memories, linear vector scan); 10K+ is unproven. Full docs, benchmarks (96.0% engram-v3, methodology and caveats included), and source: [github.com/Danialsamadi/synapse](https://github.com/Danialsamadi/synapse).
 
 GPL-3.0-only.

--- a/apps/mcp-server/package.json
+++ b/apps/mcp-server/package.json
@@ -33,12 +33,21 @@
     "prepack": "tsup"
   },
   "dependencies": {
-    "@huggingface/transformers": "^4.2.0",
     "@modelcontextprotocol/sdk": "^1.12.0",
     "better-sqlite3": "^12.11.1",
     "zod": "^3.24.1"
   },
+  "peerDependencies": {
+    "@huggingface/transformers": "^4.2.0"
+  },
+  "peerDependenciesMeta": {
+    "@huggingface/transformers": {
+      "optional": true
+    }
+  },
   "devDependencies": {
+    "@huggingface/transformers": "^4.2.0",
+    "@synapse/cli": "workspace:*",
     "@synapse/core": "workspace:*",
     "@synapse/store": "workspace:*",
     "@synapse/embeddings": "workspace:*",

--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -1,12 +1,22 @@
-import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { resolveDbPath } from "@synapse/core";
-import { MemoryRepository } from "@synapse/store";
-import { createSynapseMcpServer } from "./server.js";
+import { runCli } from "@synapse/cli";
 
-// Real semantic embeddings by default; SYNAPSE_EMBED_PROVIDER=hash|openai overrides.
-process.env.SYNAPSE_EMBED_PROVIDER ??= "local";
+// `synapse-os` with no args (or `mcp`) = stdio MCP server, so existing
+// `npx -y synapse-os` MCP client configs keep working. Any other first arg
+// dispatches to the CLI — same store, env, and write guards.
+const argv = process.argv.slice(2);
 
-const repo = new MemoryRepository({ path: resolveDbPath() });
+if (argv.length > 0 && argv[0] !== "mcp") {
+  await runCli(argv);
+} else {
+  const { StdioServerTransport } = await import("@modelcontextprotocol/sdk/server/stdio.js");
+  const { MemoryRepository, runDecay } = await import("@synapse/store");
+  const { createSynapseMcpServer } = await import("./server.js");
 
-const server = createSynapseMcpServer(repo);
-await server.connect(new StdioServerTransport());
+  const repo = new MemoryRepository({ path: resolveDbPath() });
+  const server = createSynapseMcpServer(repo);
+  // Long-lived hosts (gateways) can keep one process up for weeks; re-run the
+  // TTL/decay sweep daily, not just at startup. unref: never holds exit open.
+  setInterval(() => runDecay(repo), 24 * 3600 * 1000).unref();
+  await server.connect(new StdioServerTransport());
+}

--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -1,0 +1,90 @@
+# Synapse on Hermes (constrained agent hosts)
+
+Field-tested setup for Hermes-style gateways: small `/tmp`, no native toolchain, no GPU runtime, MCP over stdio.
+
+## Install
+
+```bash
+npm install -g synapse-os
+# If install scripts are blocked, or better-sqlite3 lacks a prebuilt binary:
+npm install -g synapse-os --ignore-scripts
+cd "$(npm root -g)/synapse-os" && npm rebuild better-sqlite3
+```
+
+`synapse-os` does not depend on transformers.js/ONNX — nothing large downloads.
+
+## MCP config
+
+Env vars belong in an `env:` **object** in `config.yaml`. `hermes mcp add --env KEY=VAL` currently writes `--env` into `args:` instead — write the YAML directly:
+
+```yaml
+mcpServers:
+  synapse:
+    command: node
+    args:
+      - /usr/local/lib/node_modules/synapse-os/dist/index.js
+    env:
+      SYNAPSE_DB: /root/.synapse/synapse.db
+      SYNAPSE_EMBED_PROVIDER: hash
+```
+
+(`command: npx, args: ["-y", "synapse-os"]` also works where npx is allowed.)
+
+## Embeddings in a constrained container
+
+- `hash` (shown above): zero deps, zero network, **not semantic**. Retrieval = FTS5 keyword + importance/recency/confidence. Roughly 80% useful for structured cron logs; blind to paraphrase ("fuzzy recall").
+- Real embeddings without heavy installs: Ollama on the host —
+
+  ```yaml
+    env:
+      SYNAPSE_EMBED_PROVIDER: openai
+      SYNAPSE_EMBED_BASE_URL: http://localhost:11434/v1
+      SYNAPSE_EMBED_MODEL: nomic-embed-text
+  ```
+
+  After switching, re-embed existing memories once: `synapse-os reembed`.
+
+## Logging cron runs (episodic memories that stay retrievable)
+
+Rules that make run histories work:
+
+- `type: "episodic"`, one write per run.
+- **Never set `entityKey` on run logs.** `entityKey` is a current-value slot — each new run would *supersede* the previous one and your history collapses to "latest only". (Use `entityKey` only for the job's *config/current-state* fact, e.g. `cron.tech-news-curator`.)
+- Put stable identifiers in the content and tags; pass `occurredAt` for the run time.
+
+```json
+{
+  "name": "memory_write",
+  "arguments": {
+    "type": "episodic",
+    "content": "Iran Internet Monitor run 2026-08-21T18:00:42Z (run_id=iim-4821): success. 40/40 endpoints polled, 3 anomalies, source=cron.",
+    "tags": ["iran-monitor", "cron-run"],
+    "occurredAt": "2026-08-21T18:00:42Z"
+  }
+}
+```
+
+Episodic writes are exempt from semantic dedup/absorb — near-identical run lines on consecutive days are all kept (only byte-identical content dedups).
+
+## Querying run history
+
+```json
+{ "name": "memory_retrieve",
+  "arguments": { "query": "iran monitor runs last week", "tags": ["iran-monitor"], "limit": 20 } }
+```
+
+- Relative time phrases ("yesterday", "last week", "3 days ago") become date filters automatically; event time is `occurredAt`, not write time.
+- In hash mode, keyword matching drives recall — keep consistent job names/tags in content ("Iran Internet Monitor", `run_id=`), and filter by `tags` for precision.
+
+## Feedback from chat surfaces (Telegram etc.)
+
+Wire "that's outdated" replies to `memory_feedback`: `{ "id": "<memory id from retrieve>", "verdict": "stale" }` — lowers confidence, disputes the memory, and hides it from default retrieval. `helpful` does the reverse.
+
+## Inspecting the DB while the gateway holds it
+
+The DB is WAL-mode — concurrent readers are safe: `synapse-os list`, `synapse-os export`, or read-only SQL from any process allowed to run it:
+
+```bash
+sqlite3 "file:/root/.synapse/synapse.db?mode=ro" \
+  "SELECT type, status, substr(content,1,80) FROM memories ORDER BY created_at DESC LIMIT 20"
+```

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,10 +3,19 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "main": "./src/cli.ts",
+  "types": "./src/cli.ts",
+  "exports": {
+    ".": {
+      "types": "./src/cli.ts",
+      "import": "./src/cli.ts",
+      "default": "./src/cli.ts"
+    }
+  },
   "scripts": {
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "node --import tsx --test src/**/*.test.ts",
-    "start": "tsx src/cli.ts"
+    "start": "tsx src/bin.ts"
   },
   "dependencies": {
     "@synapse/core": "workspace:*",

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+import { runCli } from "./cli.js";
+
+runCli(process.argv.slice(2)).catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, it } from "node:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runCli } from "./cli.js";
+
+describe("runCli", () => {
+  let dir: string;
+  let logs: string[];
+  const origLog = console.log;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "synapse-cli-"));
+    process.env.SYNAPSE_DB = join(dir, "test.db");
+    logs = [];
+    console.log = (...args: unknown[]) => logs.push(args.join(" "));
+  });
+
+  afterEach(() => {
+    console.log = origLog;
+    delete process.env.SYNAPSE_DB;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("remember then query round-trips through the shared store", async () => {
+    await runCli(["remember", "semantic", "User prefers TypeScript over JavaScript"]);
+    const written = JSON.parse(logs.join("\n"));
+    assert.equal(written.type, "semantic");
+
+    logs.length = 0;
+    await runCli(["query", "typescript preference"]);
+    const res = JSON.parse(logs.join("\n"));
+    assert.ok(res.memories.some((m: { content: string }) => m.content.includes("TypeScript")));
+  });
+
+  it("export lists what remember stored", async () => {
+    await runCli(["remember", "procedural", "Always run tests before committing"]);
+    logs.length = 0;
+    await runCli(["export"]);
+    const dump = JSON.parse(logs.join("\n"));
+    assert.equal(dump.memories.length, 1);
+  });
+});

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,11 +1,10 @@
-#!/usr/bin/env node
 import { MemoryTypeSchema, resolveDbPath } from "@synapse/core";
 import { MemoryRepository, RetrievalService, createEmbedder, reembedAll, writeMemory } from "@synapse/store";
 import { splitIntoMemories } from "./import.js";
 
 const dbPath = resolveDbPath;
 
-function usage(): never {
+function usage(code = 1): never {
   console.log(`synapse — Personal AI Memory OS CLI
 
 Usage:
@@ -19,17 +18,21 @@ Usage:
   synapse backup [dest]
   synapse restore <src> --force
   synapse delete <id>
+  synapse mcp                  (default: start the stdio MCP server)
 
 Types: episodic | semantic | procedural | working
 Env: SYNAPSE_DB=path/to.db (default: ~/.synapse/synapse.db)
+     SYNAPSE_EMBED_PROVIDER=hash|openai|local (default: openai if a key/base
+     URL is configured, else hash — see README for the provider matrix)
 `);
-  process.exit(1);
+  process.exit(code);
 }
 
-async function main(): Promise<void> {
-  process.env.SYNAPSE_EMBED_PROVIDER ??= "local";
-  const [cmd, ...rest] = process.argv.slice(2);
+/** Shared CLI dispatch — same store, env, and guards as the MCP server. */
+export async function runCli(argv: string[]): Promise<void> {
+  const [cmd, ...rest] = argv;
   if (!cmd) usage();
+  if (cmd === "help" || cmd === "--help" || cmd === "-h") usage(0);
 
   if (cmd === "restore") {
     // Handled before opening the repository: restoring over a live handle corrupts WAL state.
@@ -198,8 +201,3 @@ async function main(): Promise<void> {
     repo.close();
   }
 }
-
-main().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});

--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -8,6 +8,32 @@ describe("provider config", () => {
     assert.equal(loadLlmConfig().temperature, 0);
   });
 
+  it("infers openai when a key or base URL is configured but no provider is", () => {
+    process.env.SYNAPSE_EMBED_API_KEY = "sk-test";
+    try {
+      assert.equal(loadEmbeddingConfig().provider, "openai");
+    } finally {
+      delete process.env.SYNAPSE_EMBED_API_KEY;
+    }
+    process.env.SYNAPSE_EMBED_BASE_URL = "http://localhost:11434/v1";
+    try {
+      assert.equal(loadEmbeddingConfig().provider, "openai");
+    } finally {
+      delete process.env.SYNAPSE_EMBED_BASE_URL;
+    }
+  });
+
+  it("an explicit provider beats the openai inference", () => {
+    process.env.SYNAPSE_EMBED_PROVIDER = "hash";
+    process.env.SYNAPSE_EMBED_API_KEY = "sk-test";
+    try {
+      assert.equal(loadEmbeddingConfig().provider, "hash");
+    } finally {
+      delete process.env.SYNAPSE_EMBED_PROVIDER;
+      delete process.env.SYNAPSE_EMBED_API_KEY;
+    }
+  });
+
   it("coerces numeric env vars from strings", () => {
     process.env.SYNAPSE_EMBED_DIMENSIONS = "768";
     process.env.SYNAPSE_LLM_TEMPERATURE = "0.5";

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -18,8 +18,16 @@ export const LlmConfigSchema = z.object({
 export type LlmConfig = z.infer<typeof LlmConfigSchema>;
 
 export function loadEmbeddingConfig(): EmbeddingConfig {
+  // Default selection: an explicit SYNAPSE_EMBED_PROVIDER always wins; a
+  // configured OpenAI-compatible endpoint (key or base URL) implies "openai";
+  // otherwise "hash" — retrieval stays useful via FTS5 + non-vector signals,
+  // and nothing heavy downloads. "local" (transformers.js) is opt-in only.
+  const inferred =
+    process.env.SYNAPSE_EMBED_API_KEY || process.env.SYNAPSE_EMBED_BASE_URL
+      ? "openai"
+      : undefined;
   return EmbeddingConfigSchema.parse({
-    provider: process.env.SYNAPSE_EMBED_PROVIDER,
+    provider: process.env.SYNAPSE_EMBED_PROVIDER ?? inferred,
     baseUrl: process.env.SYNAPSE_EMBED_BASE_URL,
     apiKey: process.env.SYNAPSE_EMBED_API_KEY,
     model: process.env.SYNAPSE_EMBED_MODEL,

--- a/packages/embeddings/src/index.ts
+++ b/packages/embeddings/src/index.ts
@@ -1,15 +1,25 @@
 export interface EmbeddingProvider {
   readonly model: string;
+  /**
+   * Whether vectors from this provider carry meaning. Undefined = true (real
+   * providers). When false, retrieval must not rank by vector similarity and
+   * write-time semantic dedup must not run — the scores would be noise.
+   */
+  readonly semantic?: boolean;
   embed(texts: string[]): Promise<number[][]>;
 }
 
-/** Deterministic fake embeddings for tests / offline Day 1–5. */
+/** Deterministic char-frequency embeddings: zero deps, zero network — and zero
+ *  semantics. Non-semantic by default; tests that use it as a stand-in for a
+ *  real model pass `{ semantic: true }` to opt back into vector ranking. */
 export class HashEmbeddingProvider implements EmbeddingProvider {
   readonly model = "hash-embed-v0";
+  readonly semantic: boolean;
   private readonly dims: number;
 
-  constructor(dims = 32) {
+  constructor(dims = 32, opts: { semantic?: boolean } = {}) {
     this.dims = dims;
+    this.semantic = opts.semantic ?? false;
   }
 
   async embed(texts: string[]): Promise<number[][]> {

--- a/packages/embeddings/src/local.ts
+++ b/packages/embeddings/src/local.ts
@@ -23,6 +23,15 @@ export class LocalEmbeddingProvider implements EmbeddingProvider {
     this.pipe ??= import("@huggingface/transformers").then(
       ({ pipeline }) =>
         pipeline("feature-extraction", this.modelId, { dtype: "q8" }) as never,
+      (err: unknown) => {
+        throw new Error(
+          "SYNAPSE_EMBED_PROVIDER=local needs the optional @huggingface/transformers package " +
+            "(large: pulls the ONNX runtime). Install it next to synapse-os: npm i @huggingface/transformers. " +
+            "Lighter alternative with real embeddings: SYNAPSE_EMBED_PROVIDER=openai " +
+            "SYNAPSE_EMBED_BASE_URL=http://localhost:11434/v1 SYNAPSE_EMBED_MODEL=nomic-embed-text (Ollama). " +
+            `Underlying error: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      },
     );
     return this.pipe;
   }

--- a/packages/store/src/abstention.test.ts
+++ b/packages/store/src/abstention.test.ts
@@ -7,7 +7,7 @@ import { RetrievalService } from "./retrieval.js";
 describe("retrieval minScore abstention", () => {
   it("filters weak matches when minScore is set, keeps them otherwise", async () => {
     const repo = new MemoryRepository({ path: ":memory:" });
-    const retrieval = new RetrievalService(repo, new HashEmbeddingProvider());
+    const retrieval = new RetrievalService(repo, new HashEmbeddingProvider(32, { semantic: true }));
     repo.create({ userId: "local", type: "semantic", content: "User lives in Toronto" });
 
     const loose = await retrieval.retrieve({ query: "quantum chromodynamics lattice", userId: "local", limit: 8 });

--- a/packages/store/src/fts.test.ts
+++ b/packages/store/src/fts.test.ts
@@ -198,7 +198,7 @@ describe("buildMatchExpr", () => {
 describe("B′ union candidacy", () => {
   it("a vector-only hit (zero token overlap) still surfaces", async () => {
     const repo = new MemoryRepository({ path: ":memory:" });
-    const embedder = new HashEmbeddingProvider();
+    const embedder = new HashEmbeddingProvider(32, { semantic: true });
     const retrieval = new RetrievalService(repo, embedder);
     const m = repo.create({ userId: "local", type: "semantic", content: "alpha beta gamma" });
     const [vec] = await embedder.embed(["totally different words"]);
@@ -213,7 +213,7 @@ describe("B′ union candidacy", () => {
 
   it("keyword hits beyond vector top-K still surface, scored by bm25", async () => {
     const repo = new MemoryRepository({ path: ":memory:" });
-    const embedder = new HashEmbeddingProvider();
+    const embedder = new HashEmbeddingProvider(32, { semantic: true });
     const retrieval = new RetrievalService(repo, embedder);
     const target = repo.create({ userId: "local", type: "semantic", content: "the xylophone recital" });
     const [tv] = await embedder.embed([target.content]);
@@ -226,7 +226,7 @@ describe("B′ union candidacy", () => {
 
   it("falls back to legacy scoring when FTS is broken, and audits it", async () => {
     const repo = new MemoryRepository({ path: ":memory:" });
-    const embedder = new HashEmbeddingProvider();
+    const embedder = new HashEmbeddingProvider(32, { semantic: true });
     const retrieval = new RetrievalService(repo, embedder);
     const m = repo.create({ userId: "local", type: "semantic", content: "fallback fact about pottery" });
     const [v] = await embedder.embed([m.content]);
@@ -244,7 +244,7 @@ describe("B′ union candidacy", () => {
 
   it("caps candidates at K without error when eligible >> K", async () => {
     const repo = new MemoryRepository({ path: ":memory:" });
-    const embedder = new HashEmbeddingProvider();
+    const embedder = new HashEmbeddingProvider(32, { semantic: true });
     const retrieval = new RetrievalService(repo, embedder);
     for (let i = 0; i < 50; i++) {
       const m = repo.create({ userId: "local", type: "semantic", content: `note number ${i} about things` });
@@ -258,7 +258,7 @@ describe("B′ union candidacy", () => {
 
   it("audit records eligibleCount and stats reports union size", async () => {
     const repo = new MemoryRepository({ path: ":memory:" });
-    const embedder = new HashEmbeddingProvider();
+    const embedder = new HashEmbeddingProvider(32, { semantic: true });
     const retrieval = new RetrievalService(repo, embedder);
     for (let i = 0; i < 5; i++) {
       const m = repo.create({ userId: "local", type: "semantic", content: `filler memory ${i}` });
@@ -273,7 +273,7 @@ describe("B′ union candidacy", () => {
 
   it("a memory in neither keyword hits nor vector top-K is dropped from candidacy", async () => {
     const repo = new MemoryRepository({ path: ":memory:" });
-    const embedder = new HashEmbeddingProvider();
+    const embedder = new HashEmbeddingProvider(32, { semantic: true });
     const retrieval = new RetrievalService(repo, embedder);
     const query = "quokka snorkeling festival";
     const total = 45; // limit:1 -> K = max(1*4, 40) = 40, so 45 eligible guarantees a K-shortfall

--- a/packages/store/src/providers.ts
+++ b/packages/store/src/providers.ts
@@ -2,25 +2,46 @@ import { loadEmbeddingConfig, loadLlmConfig } from "@synapse/core";
 import { HashEmbeddingProvider, LocalEmbeddingProvider, OpenAiEmbeddingProvider, type EmbeddingProvider } from "@synapse/embeddings";
 import { ClaudeCliLlm, FakeLlm, OpenAiCompatLlm, type LlmClient } from "./jobs/llm.js";
 
+let reported = false;
+
 export function createEmbedder(): EmbeddingProvider {
   const cfg = loadEmbeddingConfig();
-  switch (cfg.provider) {
-    case "openai":
-      return new OpenAiEmbeddingProvider({
-        baseUrl: cfg.baseUrl,
-        apiKey: cfg.apiKey,
-        model: cfg.model,
-      });
-    case "local":
-      // Only an explicitly set model reaches the local provider — the config
-      // default ("text-embedding-3-small") is an OpenAI id, not a HF one.
-      return process.env.SYNAPSE_EMBED_MODEL
-        ? new LocalEmbeddingProvider(process.env.SYNAPSE_EMBED_MODEL)
-        : new LocalEmbeddingProvider();
-    case "hash":
-    default:
-      return new HashEmbeddingProvider();
+  const embedder = ((): EmbeddingProvider => {
+    switch (cfg.provider) {
+      case "openai":
+        return new OpenAiEmbeddingProvider({
+          baseUrl: cfg.baseUrl,
+          apiKey: cfg.apiKey,
+          model: cfg.model,
+        });
+      case "local":
+        // Only an explicitly set model reaches the local provider — the config
+        // default ("text-embedding-3-small") is an OpenAI id, not a HF one.
+        return process.env.SYNAPSE_EMBED_MODEL
+          ? new LocalEmbeddingProvider(process.env.SYNAPSE_EMBED_MODEL)
+          : new LocalEmbeddingProvider();
+      case "hash":
+      default:
+        return new HashEmbeddingProvider();
+    }
+  })();
+  // Startup report on stderr (safe under stdio MCP), once per process: which
+  // provider is active and whether its vectors mean anything.
+  if (!reported) {
+    reported = true;
+    if (embedder.semantic === false) {
+      console.error(
+        `[synapse] embeddings: ${embedder.model} — NOT semantic. Vector similarity is disabled; ` +
+          "retrieval uses FTS5 keyword search + importance/recency/confidence. For real semantic recall set " +
+          "SYNAPSE_EMBED_PROVIDER=openai (any OpenAI-compatible endpoint, incl. Ollama) or " +
+          "SYNAPSE_EMBED_PROVIDER=local (needs the optional @huggingface/transformers install). " +
+          "After switching, run: synapse-os reembed",
+      );
+    } else {
+      console.error(`[synapse] embeddings: ${embedder.model} (semantic)`);
+    }
   }
+  return embedder;
 }
 
 export function createLlm(): LlmClient {

--- a/packages/store/src/retrieval.test.ts
+++ b/packages/store/src/retrieval.test.ts
@@ -7,7 +7,7 @@ import type { Memory } from "@synapse/core";
 
 async function seeded() {
   const repo = new MemoryRepository({ path: ":memory:" });
-  const embedder = new HashEmbeddingProvider();
+  const embedder = new HashEmbeddingProvider(32, { semantic: true });
   const svc = new RetrievalService(repo, embedder);
   const add = async (type: "semantic" | "procedural" | "episodic", content: string, tags: string[] = []) => {
     const m = repo.create({ userId: "local", type, content, tags });
@@ -44,7 +44,7 @@ describe("RetrievalService", () => {
 
   it("since/until filter on event time, not write time", async () => {
     const { repo, svc } = await seeded();
-    const embedder = new HashEmbeddingProvider();
+    const embedder = new HashEmbeddingProvider(32, { semantic: true });
     // Written now, but the fact dates from a year ago (backdated import).
     const lastYear = new Date(Date.now() - 365 * 24 * 3600 * 1000).toISOString();
     const backdated = repo.create({
@@ -97,7 +97,7 @@ describe("RetrievalService", () => {
 
   it("retrieve touches lastAccessedAt on returned memories", async () => {
     const repo = new MemoryRepository({ path: ":memory:" });
-    const embedder = new HashEmbeddingProvider();
+    const embedder = new HashEmbeddingProvider(32, { semantic: true });
     const svc = new RetrievalService(repo, embedder);
     const m = repo.create({ userId: "local", type: "semantic", content: "user prefers typescript" });
     const [v] = await embedder.embed([m.content]);
@@ -111,7 +111,7 @@ describe("RetrievalService", () => {
 describe("digest", () => {
   it("puts pinned first, then by importance, capped at maxItems, excluding working", async () => {
     const repo = new MemoryRepository({ path: ":memory:" });
-    const svc = new RetrievalService(repo, new HashEmbeddingProvider());
+    const svc = new RetrievalService(repo, new HashEmbeddingProvider(32, { semantic: true }));
     repo.create({ userId: "local", type: "semantic", content: "high importance fact", importance: 0.9 });
     repo.create({ userId: "local", type: "semantic", content: "low importance fact", importance: 0.1 });
     const pinned = repo.create({
@@ -133,7 +133,7 @@ describe("digest", () => {
 describe("digest edge cases", () => {
   it("empty store returns empty items and text", () => {
     const repo = new MemoryRepository({ path: ":memory:" });
-    const svc = new RetrievalService(repo, new HashEmbeddingProvider());
+    const svc = new RetrievalService(repo, new HashEmbeddingProvider(32, { semantic: true }));
     const d = svc.digest("local");
     assert.deepEqual(d.items, []);
     assert.equal(d.text, "");
@@ -142,7 +142,7 @@ describe("digest edge cases", () => {
 
   it("excludes non-active memories even when pinned", () => {
     const repo = new MemoryRepository({ path: ":memory:" });
-    const svc = new RetrievalService(repo, new HashEmbeddingProvider());
+    const svc = new RetrievalService(repo, new HashEmbeddingProvider(32, { semantic: true }));
     const pinned = repo.create({
       userId: "local", type: "semantic", content: "pinned but stale",
       retention: { mode: "pinned", pinReason: "test" },
@@ -158,7 +158,7 @@ describe("digest edge cases", () => {
 
   it("never cuts pinned memories, even past maxItems, deterministically", () => {
     const repo = new MemoryRepository({ path: ":memory:" });
-    const svc = new RetrievalService(repo, new HashEmbeddingProvider());
+    const svc = new RetrievalService(repo, new HashEmbeddingProvider(32, { semantic: true }));
     for (let i = 0; i < 4; i++) {
       repo.create({
         userId: "local", type: "semantic", content: `pinned fact ${i}`,
@@ -216,7 +216,7 @@ describe("touch-on-retrieve affects ranking", () => {
     const dir = mkdtempSync(join(tmpdir(), "synapse-test-"));
     const path = join(dir, "t.db");
     const repo = new MemoryRepository({ path });
-    const embedder = new HashEmbeddingProvider();
+    const embedder = new HashEmbeddingProvider(32, { semantic: true });
     const svc = new RetrievalService(repo, embedder);
 
     const write = async (content: string) => {
@@ -251,7 +251,7 @@ describe("touch-on-retrieve affects ranking", () => {
 describe("retrieve audit logging", () => {
   it("retrieve logs an audit event with query and stats", async () => {
     const repo = new MemoryRepository({ path: ":memory:" });
-    const embedder = new HashEmbeddingProvider();
+    const embedder = new HashEmbeddingProvider(32, { semantic: true });
     const svc = new RetrievalService(repo, embedder);
     const m = repo.create({ userId: "local", type: "semantic", content: "test fact" });
     const [v] = await embedder.embed([m.content]);
@@ -271,7 +271,7 @@ describe("retrieve audit logging", () => {
 describe("rank-based group boost", () => {
   it("members of the best-ranked tag group get an ordinal boost; other groups do not", async () => {
     const repo = new MemoryRepository({ path: ":memory:" });
-    const embedder = new HashEmbeddingProvider();
+    const embedder = new HashEmbeddingProvider(32, { semantic: true });
     const svc = new RetrievalService(repo, embedder);
     const add = async (content: string, tags: string[]) => {
       const m = repo.create({ userId: "local", type: "semantic", content, tags });
@@ -295,7 +295,7 @@ describe("rank-based group boost", () => {
 
   it("is inert when all candidates share one tag group (no uniform score shift)", async () => {
     const repo = new MemoryRepository({ path: ":memory:" });
-    const embedder = new HashEmbeddingProvider();
+    const embedder = new HashEmbeddingProvider(32, { semantic: true });
     const svc = new RetrievalService(repo, embedder);
     for (const content of ["Roast chicken with thyme", "Chicken stock from bones"]) {
       const m = repo.create({ userId: "local", type: "semantic", content, tags: ["cooking"] });
@@ -312,7 +312,7 @@ describe("rank-based group boost", () => {
 describe("LLM rerank flag", () => {
   const seed = async (llm?: import("./jobs/llm.js").LlmClient) => {
     const repo = new MemoryRepository({ path: ":memory:" });
-    const embedder = new HashEmbeddingProvider();
+    const embedder = new HashEmbeddingProvider(32, { semantic: true });
     const svc = new RetrievalService(repo, embedder, undefined, llm);
     const ids: string[] = [];
     for (const content of ["Roast chicken with garlic and thyme", "Chicken soup with garlic broth"]) {
@@ -363,6 +363,28 @@ describe("LLM rerank flag", () => {
   });
 });
 
+describe("RetrievalService with a non-semantic embedder", () => {
+  it("scores no vector term and only considers keyword hits as candidates", async () => {
+    const repo = new MemoryRepository({ path: ":memory:" });
+    const embedder = new HashEmbeddingProvider(); // semantic: false by default
+    const svc = new RetrievalService(repo, embedder);
+    const add = async (content: string) => {
+      const m = repo.create({ userId: "local", type: "semantic", content });
+      const [v] = await embedder.embed([content]);
+      if (v) repo.saveEmbedding(m.id, v, embedder.model);
+      return m;
+    };
+    const hit = await add("User prefers TypeScript for backend work");
+    // Hash-similar shape, zero keyword overlap with the query — must not surface.
+    const noise = await add("Ordered a tuna sandwich on Tuesday");
+    const res = await svc.retrieve({ query: "typescript preference", userId: "local", limit: 5 });
+    assert.ok(res.memories.some((m) => m.id === hit.id));
+    assert.ok(!res.memories.some((m) => m.id === noise.id), "non-matching memory must not be a candidate");
+    assert.equal(res.memories[0]?.scoreBreakdown?.vector, 0, "vector term must contribute nothing");
+    repo.close();
+  });
+});
+
 describe("RetrievalService question-time anchoring", () => {
   // Measured on LongMemEval: 7 of 169 dev questions retrieved literally zero
   // memories and abstained. Cause: retrieve() called parseTimeWindow(query)
@@ -372,7 +394,7 @@ describe("RetrievalService question-time anchoring", () => {
   // before scoring — emptied the pool.
   async function dated() {
     const repo = new MemoryRepository({ path: ":memory:" });
-    const embedder = new HashEmbeddingProvider();
+    const embedder = new HashEmbeddingProvider(32, { semantic: true });
     const svc = new RetrievalService(repo, embedder);
     const add = async (content: string, observedAt: string) => {
       const m = repo.create({

--- a/packages/store/src/retrieval.ts
+++ b/packages/store/src/retrieval.ts
@@ -128,11 +128,18 @@ export class RetrievalService {
       return true;
     });
 
-    const [queryVec] = await this.embedder.embed([req.query]);
+    // Non-semantic embedder (hash): similarities would be noise. Skip the
+    // query embed, contribute 0 to every vector term, and let candidacy come
+    // from keyword search alone — FTS5 + importance/recency/confidence carry
+    // the ranking.
+    const semantic = this.embedder.semantic !== false;
+    const [queryVec] = semantic ? await this.embedder.embed([req.query]) : [undefined];
     // ponytail: linear scan over all eligible vectors — fine at personal scale
     // (thousands); the B′ union below saves scoring work, not scan work. Swap
     // the vector side to a sqlite-vec index if retrieval latency ever matters.
-    const vectors = this.repo.getEmbeddings(eligible.map((m) => m.id));
+    const vectors = semantic
+      ? this.repo.getEmbeddings(eligible.map((m) => m.id))
+      : new Map<string, number[]>();
     // (clock hoisted above — recency and decay use the same `now` as the window)
     const sims = new Map<string, number>();
     for (const m of eligible) {
@@ -150,6 +157,8 @@ export class RetrievalService {
     let candidates: Memory[];
     if (keywordRanks === null) {
       candidates = eligible; // FTS broken → legacy full scan, substring keyword below
+    } else if (!semantic) {
+      candidates = eligible.filter((m) => keywordRanks.has(m.id));
     } else {
       const K = Math.max(req.limit * 4, 40);
       const topK = new Set(

--- a/packages/store/src/write.test.ts
+++ b/packages/store/src/write.test.ts
@@ -79,6 +79,47 @@ describe("writeMemory semantic dedup", () => {
     assert.equal(repo.getEmbeddings([res.memory.id]).size, 1);
   });
 
+  it("never absorbs episodic memories: distinct run logs both survive even at cosine 0.99", async () => {
+    const repo = new MemoryRepository({ path: ":memory:" });
+    const embedder = fakeEmbedder({
+      "Monitor run 2026-08-25: success, 5 articles": [1, 0, 0],
+      "Monitor run 2026-08-26: success, 7 articles": [0.99, 0.141, 0],
+    });
+    await writeMemory(repo, embedder, {
+      userId: "local", type: "episodic", content: "Monitor run 2026-08-25: success, 5 articles",
+    });
+    const second = await writeMemory(repo, embedder, {
+      userId: "local", type: "episodic", content: "Monitor run 2026-08-26: success, 7 articles",
+    });
+    assert.ok(!("rejected" in second));
+    assert.equal(second.deduped, false);
+    assert.equal(repo.list("local", { status: "active" }).length, 2);
+  });
+
+  it("skips semantic dedup entirely when the embedder is non-semantic", async () => {
+    const repo = new MemoryRepository({ path: ":memory:" });
+    // Identical vectors, but semantic: false — cosine 1.0 must not dedup.
+    const embedder: EmbeddingProvider = {
+      model: "fake-nonsemantic", semantic: false,
+      async embed(texts) { return texts.map(() => [1, 0, 0]); },
+    };
+    await writeMemory(repo, embedder, { userId: "local", type: "semantic", content: "likes tea" });
+    const second = await writeMemory(repo, embedder, { userId: "local", type: "semantic", content: "likes green tea" });
+    assert.ok(!("rejected" in second));
+    assert.equal(second.deduped, false);
+    assert.equal(repo.list("local", { status: "active" }).length, 2);
+  });
+
+  it("exact content-hash dedup still applies under a non-semantic embedder", async () => {
+    const repo = new MemoryRepository({ path: ":memory:" });
+    const embedder = new HashEmbeddingProvider();
+    await writeMemory(repo, embedder, { userId: "local", type: "episodic", content: "same log line" });
+    const second = await writeMemory(repo, embedder, { userId: "local", type: "episodic", content: "same log line" });
+    assert.ok(!("rejected" in second));
+    assert.equal(second.deduped, true);
+    assert.equal(repo.list("local", { status: "active" }).length, 1);
+  });
+
   it("skips semantic dedup when entityKey is set (supersession wins)", async () => {
     const repo = new MemoryRepository({ path: ":memory:" });
     const embedder = fakeEmbedder({

--- a/packages/store/src/write.ts
+++ b/packages/store/src/write.ts
@@ -27,8 +27,11 @@ export type WriteOutcome = WriteResult | SecretRejection;
  * Single write path: exact content-hash dedup + entityKey supersession
  * (createWithEntitySupersede), then semantic dedup against active memories of
  * the same user+type — cosine >= 0.95 returns the existing memory, 0.92–0.95
- * absorbs into it (touch + tag union). Skipped when entityKey is set, since
- * supersession is the intended resolution there.
+ * absorbs into it (touch + tag union). Semantic dedup is skipped when:
+ * - entityKey is set (supersession is the intended resolution),
+ * - the embedder is non-semantic (hash vectors would mis-merge unrelated text),
+ * - type is episodic (distinct events legitimately read near-identical — cron
+ *   run logs must all survive; exact content-hash dedup still applies).
  */
 export async function writeMemory(
   repo: MemoryRepository,
@@ -53,7 +56,7 @@ export async function writeMemory(
   const userId = input.userId ?? "local";
   const [vec] = await embedder.embed([input.content]);
 
-  if (!input.entityKey && vec) {
+  if (!input.entityKey && vec && embedder.semantic !== false && input.type !== "episodic") {
     const exact = repo.findActiveByContentHash(userId, input.type, input.content);
     if (!exact) {
       const candidates = repo

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,9 +57,6 @@ importers:
 
   apps/mcp-server:
     dependencies:
-      '@huggingface/transformers':
-        specifier: ^4.2.0
-        version: 4.2.0
       '@modelcontextprotocol/sdk':
         specifier: ^1.12.0
         version: 1.29.0(zod@3.25.76)
@@ -70,6 +67,12 @@ importers:
         specifier: ^3.24.1
         version: 3.25.76
     devDependencies:
+      '@huggingface/transformers':
+        specifier: ^4.2.0
+        version: 4.2.0
+      '@synapse/cli':
+        specifier: workspace:*
+        version: link:../../packages/cli
       '@synapse/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -219,9 +222,6 @@ importers:
         version: 5.9.3
 
 packages:
-
-  '@emnapi/runtime@1.11.2':
-    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
 
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
@@ -561,12 +561,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-darwin-x64@0.34.5':
-    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [darwin]
-
   '@img/sharp-libvips-darwin-arm64@1.2.4':
     resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
     cpu: [arm64]
@@ -646,29 +640,6 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-
-  '@img/sharp-linux-x64@0.34.5':
-    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [linux]
-
-  '@img/sharp-linuxmusl-arm64@0.34.5':
-    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [linux]
-
-  '@img/sharp-linuxmusl-x64@0.34.5':
-    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [linux]
-
-  '@img/sharp-wasm32@0.34.5':
-    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [wasm32]
 
   '@img/sharp-win32-arm64@0.34.5':
     resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
@@ -761,11 +732,6 @@ packages:
   '@rollup/rollup-freebsd-arm64@4.62.2':
     resolution: {integrity: sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==}
     cpu: [arm64]
-    os: [freebsd]
-
-  '@rollup/rollup-freebsd-x64@4.62.2':
-    resolution: {integrity: sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==}
-    cpu: [x64]
     os: [freebsd]
 
   '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
@@ -1570,9 +1536,6 @@ packages:
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
-  tslib@2.8.1:
-    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
-
   tsup@8.5.1:
     resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
     engines: {node: '>=18'}
@@ -1647,11 +1610,6 @@ packages:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
-
-  '@emnapi/runtime@1.11.2':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
 
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
@@ -1832,11 +1790,6 @@ snapshots:
       '@img/sharp-libvips-darwin-arm64': 1.2.4
     optional: true
 
-  '@img/sharp-darwin-x64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-darwin-x64': 1.2.4
-    optional: true
-
   '@img/sharp-libvips-darwin-arm64@1.2.4':
     optional: true
 
@@ -1890,26 +1843,6 @@ snapshots:
   '@img/sharp-linux-s390x@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linux-s390x': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-x64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-x64': 1.2.4
-    optional: true
-
-  '@img/sharp-linuxmusl-arm64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
-    optional: true
-
-  '@img/sharp-linuxmusl-x64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
-    optional: true
-
-  '@img/sharp-wasm32@0.34.5':
-    dependencies:
-      '@emnapi/runtime': 1.11.2
     optional: true
 
   '@img/sharp-win32-arm64@0.34.5':
@@ -1990,9 +1923,6 @@ snapshots:
     optional: true
 
   '@rollup/rollup-freebsd-arm64@4.62.2':
-    optional: true
-
-  '@rollup/rollup-freebsd-x64@4.62.2':
     optional: true
 
   '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
@@ -2672,7 +2602,6 @@ snapshots:
       '@rollup/rollup-darwin-arm64': 4.62.2
       '@rollup/rollup-darwin-x64': 4.62.2
       '@rollup/rollup-freebsd-arm64': 4.62.2
-      '@rollup/rollup-freebsd-x64': 4.62.2
       '@rollup/rollup-linux-arm-gnueabihf': 4.62.2
       '@rollup/rollup-linux-arm-musleabihf': 4.62.2
       '@rollup/rollup-linux-arm64-gnu': 4.62.2
@@ -2750,14 +2679,12 @@ snapshots:
       semver: 7.8.5
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.34.5
-      '@img/sharp-darwin-x64': 0.34.5
       '@img/sharp-libvips-darwin-arm64': 1.2.4
       '@img/sharp-libvips-darwin-x64': 1.2.4
       '@img/sharp-libvips-linux-arm': 1.2.4
       '@img/sharp-libvips-linux-arm64': 1.2.4
       '@img/sharp-libvips-linux-ppc64': 1.2.4
       '@img/sharp-libvips-linux-riscv64': 1.2.4
-      '@img/sharp-libvips-linux-s390x': 1.2.4
       '@img/sharp-libvips-linux-x64': 1.2.4
       '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
       '@img/sharp-libvips-linuxmusl-x64': 1.2.4
@@ -2766,10 +2693,6 @@ snapshots:
       '@img/sharp-linux-ppc64': 0.34.5
       '@img/sharp-linux-riscv64': 0.34.5
       '@img/sharp-linux-s390x': 0.34.5
-      '@img/sharp-linux-x64': 0.34.5
-      '@img/sharp-linuxmusl-arm64': 0.34.5
-      '@img/sharp-linuxmusl-x64': 0.34.5
-      '@img/sharp-wasm32': 0.34.5
       '@img/sharp-win32-arm64': 0.34.5
       '@img/sharp-win32-ia32': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
@@ -2873,9 +2796,6 @@ snapshots:
   tree-kill@1.2.2: {}
 
   ts-interface-checker@0.1.13: {}
-
-  tslib@2.8.1:
-    optional: true
 
   tsup@8.5.1(tsx@4.23.0)(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
Addresses the critical adoption blockers from the Hermes constrained-host integration feedback (both rounds): heavy ML forced on every install, MCP-only published package, hash-vector noise in ranking, invisible episodic cron logs, and overclaiming docs.

## Embeddings: opt-in weight, honest defaults ( B1)

- `@huggingface/transformers` is now an **optional peer** of `synapse-os` — `npx -y synapse-os` pulls no ONNX runtime (tarball ~36 kB). `SYNAPSE_EMBED_PROVIDER=local` without the package fails with install guidance and points at Ollama as the lighter real-embedding path.
- Default selection: explicit `SYNAPSE_EMBED_PROVIDER` wins → configured `SYNAPSE_EMBED_API_KEY`/`SYNAPSE_EMBED_BASE_URL` implies `openai` → otherwise `hash` with a loud stderr warning.
- Providers carry a `semantic` flag. In non-semantic (hash) mode the vector term is disabled instead of injecting noise: retrieval skips the query embed, scores 0 for vector, and candidacy is FTS5-keyword-only. `GET /health` and startup stderr report the active model and whether vectors are meaningful.

## CLI in the published package ( B2,  B12)

- `synapse-os remember | query | list | get | delete | import | export | reembed | backup | restore` — reuses `packages/cli` (`runCli` export), no forked logic.
- No args (or `mcp`) still starts the stdio MCP server: existing `npx -y synapse-os` client configs are untouched (smoke-tested via JSON-RPC `initialize` + `tools/list`).

## Episodic / cron reliability ( B10)

- Episodic memories are **never semantically absorbed/deduped** — distinct run logs with near-identical wording all survive; exact content-hash dedup still applies. Semantic dedup is also skipped whenever the embedder is non-semantic.
- `integrations/hermes/`: correct `env:`-object MCP YAML (not `--env` args), `--ignore-scripts` install path, cron-log patterns — including *why run logs must not carry `entityKey`* (each run would supersede the last), and WAL read-only DB inspection.
- Long-lived MCP processes re-run the TTL/decay sweep daily, not just at startup ( B13).

## Docs honesty (D1–D4)

- Provider matrix with per-provider semantics / install weight / network expectations.
- "Local-first", dependency, and scale claims scoped to what is measured; stdio-vs-HTTP packaging clarified.
- Golden-case evals now measured in worst-case hash mode: precision@5 0.969 (was 0.984 with stub vectors treated as semantic), stale-fact rate 0.000, pass rate 0.969 — still above the 0.95 gate.

## Verification

- `pnpm typecheck`: 9/9 packages clean; `pnpm test`: 0 failures across all packages; golden evals pass the gate.
- New tests: provider default selection, non-semantic ranking/candidacy, episodic non-absorb, exact-dedup persistence, `runCli` round-trips.
- Built bundle smoke-tested in both CLI and MCP modes; `npm pack --dry-run` confirms no ML runtime in the tarball.

Deferred (unchanged scope): sqlite-vec / binary vectors (P4), consolidation webhook (P5), `project` field / multi-user (P6); Ollama documented in place of a `local-lite` provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
