### PR TITLE
Field-incident hardening: recoverable dedup, version-skew diagnosability, router hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning: [S
 
 ## [Unreleased]
 
+### Added
+- Dedup/absorb audit events now record the discarded incoming content
+  (`droppedContent`) — a false-positive merge is recoverable from the audit log
+  instead of being silent data loss (field incident on a stale pre-0.4.0 server).
+- MCP server stamps a `startup` audit event with its running version, so a
+  long-lived pre-upgrade process is diagnosable from the DB.
+- Hermes guide: upgrade/restart procedure for long-lived MCP processes, and a
+  CLI-vs-MCP disagreement checklist (version skew, `SYNAPSE_DB` divergence,
+  hash-mode candidacy). Verified and documented that SQLite WAL is *not*
+  eventually consistent — readers always see committed writes.
+- OpenAI-compatible embedder: a 404/405 from `/embeddings` now hints that the
+  base URL is likely a chat-only router and points at embeddings-capable
+  endpoints (field report: LLM routers commonly lack `/embeddings`).
+
 ## [0.4.0] - 2026-08-26
 
 ### Added

--- a/apps/mcp-server/src/server.test.ts
+++ b/apps/mcp-server/src/server.test.ts
@@ -15,6 +15,15 @@ async function connected() {
 }
 
 describe("synapse MCP server", () => {
+  it("stamps a startup audit with the running version, so stale processes are diagnosable", async () => {
+    const { repo } = await connected();
+    const events = repo.listAudit("startup");
+    assert.equal(events.length, 1);
+    const detail = JSON.parse(events[0]!.detail) as { version: string };
+    assert.ok(typeof detail.version === "string" && detail.version.length > 0);
+    repo.close();
+  });
+
   it("lists both memory tools", async () => {
     const { repo, client } = await connected();
     const { tools } = await client.listTools();

--- a/apps/mcp-server/src/server.ts
+++ b/apps/mcp-server/src/server.ts
@@ -23,6 +23,10 @@ export function createSynapseMcpServer(repo: MemoryRepository): McpServer {
   // PKG_VERSION is injected by tsup at build time from package.json.
   const server = new McpServer({ name: "synapse", version: process.env.PKG_VERSION ?? "0.0.0-dev" });
 
+  // Version stamp: long-lived hosts can keep a pre-upgrade process serving for
+  // days — this audit row is how a CLI or SQL reader detects the skew.
+  repo.addAudit("startup", JSON.stringify({ version: process.env.PKG_VERSION ?? "0.0.0-dev" }));
+
   // The MCP path is the flagship install and has no job runner: sweep once at
   // startup so TTL expiry, decay archival, and the confidence floor actually
   // run for npx-only users.

--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -80,6 +80,32 @@ Episodic writes are exempt from semantic dedup/absorb — near-identical run lin
 
 Wire "that's outdated" replies to `memory_feedback`: `{ "id": "<memory id from retrieve>", "verdict": "stale" }` — lowers confidence, disputes the memory, and hides it from default retrieval. `helpful` does the reverse.
 
+## Upgrades: restart long-lived MCP processes
+
+Hosts that spawn `npx -y synapse-os` per session pick up upgrades automatically. Gateway/watchdog hosts that keep one MCP process alive for days do **not** — the old code keeps serving until the process restarts. Field incident: a pre-0.4.0 process kept absorbing writes with hash-vector dedup for a day after the 0.4.0 upgrade. After upgrading: restart the synapse MCP process (or the gateway).
+
+To check which version is actually serving, read the newest `startup` audit row:
+
+```bash
+sqlite3 "file:/root/.synapse/synapse.db?mode=ro" \
+  "SELECT detail, created_at FROM audit_log WHERE action='startup' ORDER BY created_at DESC LIMIT 1"
+```
+
+## If the CLI and the MCP server seem to disagree
+
+SQLite WAL is **not** eventually consistent — any reader sees all committed writes immediately, including uncheckpointed ones (verified with a live writer holding the DB open). If the two paths return different results, the cause is one of:
+
+1. **Version skew** — a stale pre-upgrade MCP process (check the `startup` audit above). Old versions also had different retrieval candidacy, so the *same query* can return different results across versions.
+2. **Different databases** — `SYNAPSE_DB` set in the MCP `env:` but not in your shell (or vice versa); each path silently uses its own file. Compare paths first.
+3. **Hash-mode candidacy** — in hash mode, `query` only surfaces memories with FTS keyword overlap; `list` shows everything. A memory "missing" from a query but present in `list` is a wording mismatch, not a storage problem.
+
+If a write "disappeared", check the dedup/absorb audit rows — since 0.4.1 they carry the discarded content (`droppedContent`), so a false-positive merge is recoverable:
+
+```bash
+sqlite3 "file:/root/.synapse/synapse.db?mode=ro" \
+  "SELECT detail FROM audit_log WHERE action IN ('dedup','absorb') ORDER BY created_at DESC LIMIT 5"
+```
+
 ## Inspecting the DB while the gateway holds it
 
 The DB is WAL-mode — concurrent readers are safe: `synapse-os list`, `synapse-os export`, or read-only SQL from any process allowed to run it:

--- a/packages/embeddings/src/index.test.ts
+++ b/packages/embeddings/src/index.test.ts
@@ -1,6 +1,31 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { HashEmbeddingProvider, cosineSimilarity } from "./index.js";
+import { HashEmbeddingProvider, OpenAiEmbeddingProvider, cosineSimilarity } from "./index.js";
+
+describe("OpenAiEmbeddingProvider error hints", () => {
+  it("a 404 from /embeddings explains that the base URL is likely chat-only", async () => {
+    const orig = globalThis.fetch;
+    globalThis.fetch = async () => new Response("Not Found", { status: 404 });
+    try {
+      const p = new OpenAiEmbeddingProvider({ baseUrl: "http://router.local/v1" });
+      await assert.rejects(p.embed(["x"]), /may not serve \/embeddings.*Ollama/s);
+    } finally {
+      globalThis.fetch = orig;
+    }
+  });
+
+  it("other failures keep the plain status error, no misleading hint", async () => {
+    const orig = globalThis.fetch;
+    globalThis.fetch = async () => new Response("upstream boom", { status: 500 });
+    try {
+      const p = new OpenAiEmbeddingProvider({ baseUrl: "http://router.local/v1" });
+      await assert.rejects(p.embed(["x"]), (err: Error) =>
+        /failed \(500\)/.test(err.message) && !/embeddings-capable/.test(err.message));
+    } finally {
+      globalThis.fetch = orig;
+    }
+  });
+});
 
 describe("HashEmbeddingProvider", () => {
   it("is deterministic and self-similar", async () => {

--- a/packages/embeddings/src/openai.ts
+++ b/packages/embeddings/src/openai.ts
@@ -29,7 +29,14 @@ export class OpenAiEmbeddingProvider implements EmbeddingProvider {
     });
     if (!res.ok) {
       const body = await res.text().catch(() => "");
-      throw new Error(`OpenAI embedding request failed (${res.status}): ${body}`);
+      // 404/405 on /embeddings usually means the base URL is a chat-only
+      // router/proxy — steer to an endpoint that actually serves embeddings.
+      const hint =
+        res.status === 404 || res.status === 405
+          ? " Hint: this base URL may not serve /embeddings (chat-completion routers don't). " +
+            "Point SYNAPSE_EMBED_BASE_URL at an embeddings-capable endpoint (e.g. Ollama: http://localhost:11434/v1 with SYNAPSE_EMBED_MODEL=nomic-embed-text)."
+          : "";
+      throw new Error(`OpenAI embedding request failed (${res.status}): ${body}${hint}`);
     }
     const data = (await res.json()) as { data: { embedding: number[]; index: number }[] };
     return data.data.sort((a, b) => a.index - b.index).map((d) => d.embedding);

--- a/packages/store/src/write.test.ts
+++ b/packages/store/src/write.test.ts
@@ -79,6 +79,22 @@ describe("writeMemory semantic dedup", () => {
     assert.equal(repo.getEmbeddings([res.memory.id]).size, 1);
   });
 
+  it("audits the discarded content on dedup and absorb, so a false positive is recoverable", async () => {
+    const repo = new MemoryRepository({ path: ":memory:" });
+    const embedder = fakeEmbedder({
+      a: [1, 0, 0],
+      "absorbed away": [0.93, Math.sqrt(1 - 0.93 * 0.93), 0], // absorb band
+      "deduped away": [0.99, 0.141, 0], // reject band
+    });
+    await writeMemory(repo, embedder, { userId: "local", type: "semantic", content: "a" });
+    await writeMemory(repo, embedder, { userId: "local", type: "semantic", content: "absorbed away" });
+    await writeMemory(repo, embedder, { userId: "local", type: "semantic", content: "deduped away" });
+    const absorb = JSON.parse(repo.listAudit("absorb")[0]!.detail);
+    const dedup = JSON.parse(repo.listAudit("dedup")[0]!.detail);
+    assert.equal(absorb.droppedContent, "absorbed away");
+    assert.equal(dedup.droppedContent, "deduped away");
+  });
+
   it("never absorbs episodic memories: distinct run logs both survive even at cosine 0.99", async () => {
     const repo = new MemoryRepository({ path: ":memory:" });
     const embedder = fakeEmbedder({

--- a/packages/store/src/write.ts
+++ b/packages/store/src/write.ts
@@ -72,14 +72,16 @@ export async function writeMemory(
       }
       if (best && best.sim >= DEDUP_REJECT_THRESHOLD) {
         repo.touchAccessed([best.memory.id]);
-        repo.addAudit("dedup", JSON.stringify({ keptId: best.memory.id, sim: best.sim }));
+        // droppedContent: a false-positive dedup discards the incoming write —
+        // the audit row is the only place it can be recovered from.
+        repo.addAudit("dedup", JSON.stringify({ keptId: best.memory.id, sim: best.sim, droppedContent: input.content }));
         return { memory: best.memory, supersededIds: [], deduped: true };
       }
       if (best && best.sim >= DEDUP_ABSORB_THRESHOLD) {
         const tags = [...new Set([...best.memory.tags, ...(input.tags ?? [])])];
         const updated = repo.update(best.memory.id, { tags }) ?? best.memory;
         repo.touchAccessed([updated.id]);
-        repo.addAudit("absorb", JSON.stringify({ keptId: updated.id, sim: best.sim }));
+        repo.addAudit("absorb", JSON.stringify({ keptId: updated.id, sim: best.sim, droppedContent: input.content }));
         return { memory: updated, supersededIds: [], deduped: true, absorbed: true };
       }
     }


### PR DESCRIPTION
Hardening from the first day of real Hermes production use. Root cause of both field incidents was a single thing — the gateway kept a pre-0.4.0 MCP process serving after the upgrade — but the incidents exposed two real product gaps and one docs gap, fixed here.

## Fixes

- **Recoverable dedup/absorb**: audit events for `dedup` and `absorb` now include the discarded incoming content (`droppedContent`). A false-positive merge (the incident: a study path absorbed into an unrelated memory by v0.3.2 hash vectors) is now recoverable from the audit log instead of silent data loss.
- **Version-skew diagnosability**: the MCP server stamps a `startup` audit event with its running version. A stale long-lived process is now detectable with one read-only SQL query instead of `ps` archaeology.
- **Chat-router embedding hint**: a 404/405 from `/embeddings` on an OpenAI-compatible base URL now explains the endpoint is likely chat-only and points at embeddings-capable options (Ollama). Field report: LLM routers commonly lack `/embeddings`.

## Docs (`integrations/hermes/`)

- Upgrade procedure: long-lived gateway MCP processes must be restarted after upgrading; per-session `npx` hosts are immune.
- CLI-vs-MCP disagreement checklist: version skew → `SYNAPSE_DB` divergence → hash-mode candidacy.
- Corrects the "WAL eventual consistency" folklore from the field report: SQLite WAL readers always see committed writes, verified empirically against a live writer holding the DB open with an uncheckpointed WAL.

## Verification

- New failing-first tests: audit `droppedContent` on both dedup bands, `startup` version stamp, 404 hint present / 500 unhinted.
- `pnpm typecheck` 9/9 clean, `pnpm test` 0 failures across all packages.


