### PR TITLE
Restore stranding guard: refuse restore while the DB has a live holder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning: [S
 
 ## [Unreleased]
 
+### Added
+- Restore stranding guard: `synapse-os restore` now refuses while another
+  process holds the database (probe: leaving WAL mode requires exclusive
+  access). Restoring under a live MCP server stranded its writes on the old
+  file — field incident. Stop the server, restore, restart.
+
 ## [0.4.1] - 2026-08-27
 
 ### Added

--- a/integrations/hermes/README.md
+++ b/integrations/hermes/README.md
@@ -99,6 +99,8 @@ SQLite WAL is **not** eventually consistent — any reader sees all committed wr
 2. **Different databases** — `SYNAPSE_DB` set in the MCP `env:` but not in your shell (or vice versa); each path silently uses its own file. Compare paths first.
 3. **Hash-mode candidacy** — in hash mode, `query` only surfaces memories with FTS keyword overlap; `list` shows everything. A memory "missing" from a query but present in `list` is a wording mismatch, not a storage problem.
 
+**Restore needs the server stopped.** `synapse-os restore` refuses while a running MCP server/gateway holds the database — restoring under a live holder strands that process's writes on the old file. Stop the gateway (or the synapse child process), restore, then start it again.
+
 If a write "disappeared", check the dedup/absorb audit rows — since 0.4.1 they carry the discarded content (`droppedContent`), so a false-positive merge is recoverable:
 
 ```bash

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -19,10 +19,12 @@
   },
   "dependencies": {
     "@synapse/core": "workspace:*",
+    "@synapse/embeddings": "workspace:*",
     "@synapse/store": "workspace:*",
-    "@synapse/embeddings": "workspace:*"
+    "better-sqlite3": "^12.11.1"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "^7.6.12",
     "@types/node": "^22.10.5",
     "tsx": "^4.19.2",
     "typescript": "^5.7.2"

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -34,6 +34,30 @@ describe("runCli", () => {
     assert.ok(res.memories.some((m: { content: string }) => m.content.includes("TypeScript")));
   });
 
+  it("restore refuses while another connection holds the DB (stranding guard)", async () => {
+    await runCli(["remember", "semantic", "original fact before restore"]);
+    const backup = join(dir, "backup.db");
+    await runCli(["backup", backup]);
+
+    const { default: Database } = await import("better-sqlite3");
+    const holder = new Database(process.env.SYNAPSE_DB!); // simulates a running MCP server
+    holder.pragma("journal_mode = WAL");
+    try {
+      logs.length = 0;
+      await runCli(["restore", backup, "--force"]);
+      assert.equal(process.exitCode, 1, "restore must refuse under a live holder");
+      assert.ok(!logs.join("\n").includes("Restored"), "must not report success");
+    } finally {
+      process.exitCode = 0;
+      holder.close();
+    }
+
+    // Holder gone → the same restore succeeds.
+    logs.length = 0;
+    await runCli(["restore", backup, "--force"]);
+    assert.ok(logs.join("\n").includes("Restored"));
+  });
+
   it("export lists what remember stored", async () => {
     await runCli(["remember", "procedural", "Always run tests before committing"]);
     logs.length = 0;

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -42,8 +42,31 @@ export async function runCli(argv: string[]): Promise<void> {
       console.error(`This overwrites ${dbPath()}. Re-run with --force to confirm.`);
       process.exit(1);
     }
-    const { copyFileSync, rmSync } = await import("node:fs");
+    const { copyFileSync, rmSync, existsSync } = await import("node:fs");
     const target = dbPath();
+    // Stranding guard: a live holder (running MCP server/gateway) keeps its open
+    // handle after the copy — its writes diverge from the restored file. Probe:
+    // leaving WAL mode needs exclusive access, so it fails iff a holder exists.
+    if (existsSync(target)) {
+      const { default: Database } = await import("better-sqlite3");
+      let live = false;
+      const probe = new Database(target, { timeout: 200 });
+      try {
+        live = probe.pragma("journal_mode = delete", { simple: true }) !== "delete";
+      } catch {
+        live = true; // SQLITE_BUSY → someone holds it
+      } finally {
+        probe.close();
+      }
+      if (live) {
+        console.error(
+          `${target} is open in another process (a running synapse MCP server or gateway). ` +
+            "Restoring under a live holder strands its writes — stop that process, then re-run restore.",
+        );
+        process.exitCode = 1;
+        return;
+      }
+    }
     rmSync(`${target}-wal`, { force: true });
     rmSync(`${target}-shm`, { force: true });
     copyFileSync(src, target);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,7 +109,13 @@ importers:
       '@synapse/store':
         specifier: workspace:*
         version: link:../store
+      better-sqlite3:
+        specifier: ^12.11.1
+        version: 12.11.1
     devDependencies:
+      '@types/better-sqlite3':
+        specifier: ^7.6.12
+        version: 7.6.13
       '@types/node':
         specifier: ^22.10.5
         version: 22.20.1
@@ -222,6 +228,9 @@ importers:
         version: 5.9.3
 
 packages:
+
+  '@emnapi/runtime@1.11.3':
+    resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
 
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
@@ -561,6 +570,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
   '@img/sharp-libvips-darwin-arm64@1.2.4':
     resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
     cpu: [arm64]
@@ -640,6 +655,29 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
 
   '@img/sharp-win32-arm64@0.34.5':
     resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
@@ -732,6 +770,11 @@ packages:
   '@rollup/rollup-freebsd-arm64@4.62.2':
     resolution: {integrity: sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.62.2':
+    resolution: {integrity: sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==}
+    cpu: [x64]
     os: [freebsd]
 
   '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
@@ -1536,6 +1579,9 @@ packages:
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
   tsup@8.5.1:
     resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
     engines: {node: '>=18'}
@@ -1610,6 +1656,11 @@ packages:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
+
+  '@emnapi/runtime@1.11.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
@@ -1790,6 +1841,11 @@ snapshots:
       '@img/sharp-libvips-darwin-arm64': 1.2.4
     optional: true
 
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
   '@img/sharp-libvips-darwin-arm64@1.2.4':
     optional: true
 
@@ -1843,6 +1899,26 @@ snapshots:
   '@img/sharp-linux-s390x@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.11.3
     optional: true
 
   '@img/sharp-win32-arm64@0.34.5':
@@ -1923,6 +1999,9 @@ snapshots:
     optional: true
 
   '@rollup/rollup-freebsd-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.62.2':
     optional: true
 
   '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
@@ -2602,6 +2681,7 @@ snapshots:
       '@rollup/rollup-darwin-arm64': 4.62.2
       '@rollup/rollup-darwin-x64': 4.62.2
       '@rollup/rollup-freebsd-arm64': 4.62.2
+      '@rollup/rollup-freebsd-x64': 4.62.2
       '@rollup/rollup-linux-arm-gnueabihf': 4.62.2
       '@rollup/rollup-linux-arm-musleabihf': 4.62.2
       '@rollup/rollup-linux-arm64-gnu': 4.62.2
@@ -2679,12 +2759,14 @@ snapshots:
       semver: 7.8.5
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
       '@img/sharp-libvips-darwin-arm64': 1.2.4
       '@img/sharp-libvips-darwin-x64': 1.2.4
       '@img/sharp-libvips-linux-arm': 1.2.4
       '@img/sharp-libvips-linux-arm64': 1.2.4
       '@img/sharp-libvips-linux-ppc64': 1.2.4
       '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
       '@img/sharp-libvips-linux-x64': 1.2.4
       '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
       '@img/sharp-libvips-linuxmusl-x64': 1.2.4
@@ -2693,6 +2775,10 @@ snapshots:
       '@img/sharp-linux-ppc64': 0.34.5
       '@img/sharp-linux-riscv64': 0.34.5
       '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
       '@img/sharp-win32-arm64': 0.34.5
       '@img/sharp-win32-ia32': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
@@ -2796,6 +2882,9 @@ snapshots:
   tree-kill@1.2.2: {}
 
   ts-interface-checker@0.1.13: {}
+
+  tslib@2.8.1:
+    optional: true
 
   tsup@8.5.1(tsx@4.23.0)(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
Closes out the second field incident from the Hermes day-one report ("restore stranding").

**Problem:** `synapse-os restore --force` copies over the database while a long-lived MCP server still holds its open handle — the server keeps writing to the stranded old file and state diverges silently.

**Fix:** before touching anything, restore probes for a live holder: switching the target out of WAL journal mode requires exclusive access, so the pragma fails (or reports no change) exactly when another connection exists. On a live holder, restore refuses with instructions to stop the server first; with no holder, behavior is unchanged.

**Verification:** failing-first test with an in-process second connection; cross-process smoke test on the built bundle (refuses with exit 1 under a live `better-sqlite3` holder, succeeds after the holder exits). `pnpm typecheck` 9/9, `pnpm test` 0 failures. Hermes guide and CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nvvq3ZqAh6PUSALSo3vRV4
